### PR TITLE
fix: ensure selected language is within available options

### DIFF
--- a/src/language.ts
+++ b/src/language.ts
@@ -60,6 +60,9 @@ export class Language {
                 || this.opts.defaultLanguage
                 || 'en';
             lang = this.getLangFromDialect(lang);
+            if (!this.opts.availableLangs.includes(lang)){
+                lang = this.opts.defaultLanguage || 'en'
+            }
             if (resetCookie) {
                 this.manageCookie(lang);
             }


### PR DESCRIPTION
Added a check to verify if the selected language is included in the available languages. If not, it defaults to the configured default language or 'en'. This ensures the application does not set an unsupported language.